### PR TITLE
[Android] 스타크&Stitch - 카드 추가 기능

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,6 +21,10 @@ android {
         enabled = true
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/android/app/src/main/java/com/example/todolist/model/Status.kt
+++ b/android/app/src/main/java/com/example/todolist/model/Status.kt
@@ -1,0 +1,7 @@
+package com.example.todolist.model
+
+enum class Status(val status: String) {
+    TODO("todo"),
+    IN_PROGRESS("inProgress"),
+    DONE("done")
+}

--- a/android/app/src/main/java/com/example/todolist/model/Task.kt
+++ b/android/app/src/main/java/com/example/todolist/model/Task.kt
@@ -1,0 +1,8 @@
+package com.example.todolist.model
+
+data class Task(
+    val title: String?,
+    val content: String?,
+    val status: Status,
+    val author: String = "Android"
+)

--- a/android/app/src/main/java/com/example/todolist/ui/Dialog.kt
+++ b/android/app/src/main/java/com/example/todolist/ui/Dialog.kt
@@ -1,0 +1,90 @@
+package com.example.todolist.ui
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import com.example.todolist.databinding.DialogNewCardBinding
+import com.example.todolist.model.Status
+import com.example.todolist.model.Task
+
+class Dialog : DialogFragment() {
+    private var _binding: DialogNewCardBinding? = null
+    private val binding get() = _binding
+    private val viewModel: ViewModel by activityViewModels()
+    private var titleFlag = false
+    private var contentsFlag = false
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DialogNewCardBinding.inflate(inflater, container, false)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT)) // 다이얼로그의 곡선 주변에 배경색을 맞춰주는 코드
+        dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
+        dialog?.setCanceledOnTouchOutside(false) // 다이얼로그 외부의 영역 터치 시 취소 불가능
+
+        return binding?.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding?.btnCancel?.setOnClickListener { dismiss() }
+
+        binding?.etTitle?.addTextChangedListener(titleListener)
+        binding?.etContents?.addTextChangedListener(contentsListener)
+
+        binding?.btnRegister?.setOnClickListener {
+            val task = Task(
+                binding?.etTitle?.text?.toString(),
+                binding?.etContents?.text?.toString(),
+                Status.TODO
+            )
+            viewModel.addTask(task)
+            dismiss()
+        }
+    }
+
+    private val titleListener = object : TextWatcher {
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun afterTextChanged(s: Editable?) {
+            if (s != null) {
+                titleFlag = when {
+                    s.isEmpty() -> false
+                    else -> true
+                }
+            }
+            flagCheck()
+        }
+    }
+
+    private val contentsListener = object : TextWatcher {
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun afterTextChanged(s: Editable?) {
+            if (s != null) {
+                contentsFlag = when {
+                    s.isEmpty() -> false
+                    else -> true
+                }
+            }
+            flagCheck()
+        }
+    }
+
+    fun flagCheck() {
+        binding?.btnRegister?.isEnabled = titleFlag && contentsFlag
+    }
+}

--- a/android/app/src/main/java/com/example/todolist/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/example/todolist/ui/MainActivity.kt
@@ -23,6 +23,11 @@ class MainActivity : AppCompatActivity() {
         viewModel.history.observe(this) { histories ->
             historyAdapter.submitList(histories)
         }
+
+        binding.includeTodo?.btnTodoAdd?.setOnClickListener {
+            val dialog = Dialog()
+            dialog.show(supportFragmentManager, "Dialog")
+        }
     }
 
     private fun onDrawerEvent() {

--- a/android/app/src/main/java/com/example/todolist/ui/ViewModel.kt
+++ b/android/app/src/main/java/com/example/todolist/ui/ViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.todolist.model.ActionType.*
 import com.example.todolist.model.History
+import com.example.todolist.model.Task
 
 class ViewModel : ViewModel() {
 
@@ -12,8 +13,18 @@ class ViewModel : ViewModel() {
     val history: LiveData<List<History>>
         get() = _history
 
+    private val todoItems: MutableList<Task> = mutableListOf()
+    private var _todoTask = MutableLiveData<MutableList<Task>>()
+    val todoTask: LiveData<MutableList<Task>>
+        get() = _todoTask
+
     fun loadDummyData() {
         _history.value = getDummyData()
+    }
+
+    fun addTask(task: Task) {
+        todoItems.add(task)
+        _todoTask.value = todoItems
     }
 
     private fun getDummyData(): List<History> {

--- a/android/app/src/main/res/drawable-v24/disable_dialog_button.xml
+++ b/android/app/src/main/res/drawable-v24/disable_dialog_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/todo_light_blue" />
+    <corners android:radius="10dp" />
+</shape>

--- a/android/app/src/main/res/drawable/able_dialog_button.xml
+++ b/android/app/src/main/res/drawable/able_dialog_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/todo_blue" />
+    <corners android:radius="10dp" />
+</shape>

--- a/android/app/src/main/res/drawable/badge_background_gray.xml
+++ b/android/app/src/main/res/drawable/badge_background_gray.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/todo_gray02"/>
+</shape>

--- a/android/app/src/main/res/drawable/dialog_background_white.xml
+++ b/android/app/src/main/res/drawable/dialog_background_white.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/todo_white"/>
+    <stroke android:width="2dp" android:color="@color/todo_blue" />
+    <corners android:radius="10dp"/>
+</shape>

--- a/android/app/src/main/res/drawable/dialog_button_cancel.xml
+++ b/android/app/src/main/res/drawable/dialog_button_cancel.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/todo_grey04" />
+    <corners android:radius="10dp" />
+</shape>

--- a/android/app/src/main/res/drawable/edittext_cursor.xml
+++ b/android/app/src/main/res/drawable/edittext_cursor.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:width="1.5dp"/>
+    <solid android:color="@color/todo_grey03"/>
+</shape>

--- a/android/app/src/main/res/drawable/ic_baseline_add_24.xml
+++ b/android/app/src/main/res/drawable/ic_baseline_add_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#BDBDBD"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/android/app/src/main/res/drawable/selector_dialog_button.xml
+++ b/android/app/src/main/res/drawable/selector_dialog_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/able_dialog_button" android:state_enabled="true" />
+    <item android:drawable="@drawable/disable_dialog_button" android:state_enabled="false" />
+</selector>

--- a/android/app/src/main/res/drawable/selector_dialog_text.xml
+++ b/android/app/src/main/res/drawable/selector_dialog_text.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:color="@color/todo_white"
+        android:state_enabled="true" />
+    <item
+        android:color="@color/todo_grey05"
+        android:state_enabled="false" />
+</selector>

--- a/android/app/src/main/res/layout-sw720dp-land/activity_main.xml
+++ b/android/app/src/main/res/layout-sw720dp-land/activity_main.xml
@@ -45,6 +45,16 @@
                     android:src="@drawable/ic_baseline_menu_32" />
 
             </androidx.appcompat.widget.Toolbar>
+
+            <include
+                android:id="@+id/include_todo"
+                layout="@layout/view_todo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="56dp"
+                android:layout_marginTop="51dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tb_main" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <LinearLayout

--- a/android/app/src/main/res/layout/dialog_new_card.xml
+++ b/android/app/src/main/res/layout/dialog_new_card.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_dialog"
+            android:layout_width="540dp"
+            android:layout_height="200dp"
+            android:layout_gravity="center"
+            android:background="@drawable/dialog_background_white"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/tv_add_dialog_title"
+                style="@style/TextHeadline5.bold.20"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/label_add_new_card"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <EditText
+                android:id="@+id/et_title"
+                style="@style/Subtitle1.bold"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="20dp"
+                android:background="@android:color/transparent"
+                android:hint="@string/label_dialog_add_title"
+                android:importantForAutofill="no"
+                android:inputType="text"
+                android:textCursorDrawable="@drawable/edittext_cursor"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_dialog_title" />
+
+            <EditText
+                android:id="@+id/et_contents"
+                style="@style/Subtitle1.14"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="14dp"
+                android:background="@android:color/transparent"
+                android:hint="@string/label_dialog_add_contents"
+                android:importantForAutofill="no"
+                android:inputType="text"
+                android:textCursorDrawable="@drawable/edittext_cursor"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/et_title" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_register"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="15dp"
+                android:background="@drawable/selector_dialog_button"
+                android:enabled="false"
+                android:text="@string/label_dialog_register"
+                android:textColor="@drawable/selector_dialog_text"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_cancel"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="15dp"
+                android:background="@drawable/dialog_button_cancel"
+                android:text="@string/label_dialog_cancel"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/btn_register" />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </FrameLayout>
+</layout>

--- a/android/app/src/main/res/layout/view_todo.xml
+++ b/android/app/src/main/res/layout/view_todo.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_todo_title"
+            style="@style/Subtitle1.bold.18"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_todo_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_todo_badge"
+            style="@style/Subtitle2.bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:background="@drawable/badge_background_gray"
+            android:padding="2dp"
+            app:layout_constraintStart_toEndOf="@+id/tv_todo_title"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="113" />
+
+
+        <ImageButton
+            android:id="@+id/btn_todo_add"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="136dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/description_add_button"
+            android:src="@drawable/ic_baseline_add_24"
+            app:layout_constraintStart_toEndOf="@+id/tv_todo_badge"
+            app:layout_constraintTop_toTopOf="parent" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/values-night/strings.xml
+++ b/android/app/src/main/res/values-night/strings.xml
@@ -3,4 +3,11 @@
     <string name="label_to_do_list">TO-DO-LIST</string>
     <string name="label_menu_drawer">menu_drawer</string>
     <string name="date_format">yyyy-MM-dd HH:mm:ss</string>
+    <string name="label_todo_title">해야 할 일</string>
+    <string name="description_add_button">add_button</string>
+    <string name="label_add_new_card">새로운 카드 추가</string>
+    <string name="label_dialog_register">등록</string>
+    <string name="label_dialog_cancel">취소</string>
+    <string name="label_dialog_add_title">제목을 입력하세요</string>
+    <string name="label_dialog_add_contents">내용을 입력하세요</string>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -7,6 +7,11 @@
     <color name="teal_700">#FF018786</color>
     <color name="todo_black01">#010101</color>
     <color name="todo_grey01">#E5E5E5</color>
+    <color name="todo_gray02">#BDBDBD</color>
     <color name="todo_grey03">#828282</color>
+    <color name="todo_grey04">#E0E0E0</color>
+    <color name="todo_grey05">#66FFFFFF</color>
     <color name="todo_white">#FFFFFFFF</color>
+    <color name="todo_blue">#0075DE</color>
+    <color name="todo_light_blue">#86C6FF</color>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,4 +8,11 @@
     <string name="action_default">&lt;b>%s&lt;/b>에 &lt;b>%s&lt;/b>를 &lt;b>%s&lt;/b>하였습니다.</string>
     <string name="action_move">&lt;b>%s&lt;/b>를 &lt;b>%s&lt;/b>에서 &lt;b>%s&lt;/b>로 &lt;b>%s&lt;/b>하였습니다.</string>
     <string name="date_format">yyyy-MM-dd HH:mm:ss</string>
+    <string name="label_todo_title">해야 할 일</string>
+    <string name="description_add_button">add_button</string>
+    <string name="label_add_new_card">새로운 카드 추가</string>
+    <string name="label_dialog_register">등록</string>
+    <string name="label_dialog_cancel">취소</string>
+    <string name="label_dialog_add_title">제목을 입력하세요</string>
+    <string name="label_dialog_add_contents">내용을 입력하세요</string>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,9 +6,35 @@
         <item name="android:textSize">32sp</item>
     </style>
 
+    <style name="TextHeadline5" parent="TextAppearance.MaterialComponents.Headline5" />
+
+    <style name="TextHeadline5.bold">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextHeadline5.bold.20">
+        <item name="android:textSize">20sp</item>
+    </style>
+
     <style name="Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1" />
 
+    <style name="Subtitle1.14">
+        <item name="android:textSize">14sp</item>
+    </style>
+
+    <style name="Subtitle1.bold">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="Subtitle1.bold.18">
+        <item name="android:textSize">18sp</item>
+    </style>
+
     <style name="Subtitle2" parent="TextAppearance.MaterialComponents.Subtitle2" />
+
+    <style name="Subtitle2.bold">
+        <item name="android:textStyle">bold</item>
+    </style>
 
     <style name="Subtitle2.grey03">
         <item name="android:textColor">@color/todo_grey03</item>


### PR DESCRIPTION
## Issue

- close #17 

## Overview

- \+ 버튼을 누르면 FragmentDialog가 뜨도록 구현

- FragmentDialog 커스터마이징

- FragmentDialog에서 제목, 본문 중 하나라도 작성이 안되어 있다면 확인 버튼 비활성화 처리

- FragmentDialog 을 제외한 주변 구역을 터치 시 FragmentDialog가 dismiss 되지 않도록 처리 (오직 취소 버튼만 FragmentDialog를 dismiss)

- 활성화 버튼, 비활성화 버튼 및 커서 색 커스터마이징

- FragmentDialog의 제목, 본문 내용을 Task 객체로 묶어서 ViewModel에 전달


## Screenshot
![image](https://user-images.githubusercontent.com/79504043/162146353-dfe167ab-2c90-4ee4-86eb-6ed261b2d1b6.png)


